### PR TITLE
Add "refresh_token" to credentials array

### DIFF
--- a/GoogleStrategy.php
+++ b/GoogleStrategy.php
@@ -87,6 +87,11 @@ class GoogleStrategy extends OpauthStrategy{
 					),
 					'raw' => $userinfo
 				);
+
+				if (!empty($results->refresh_token))
+				{
+					$this->auth['credentials']['refresh_token'] = $results->refresh_token;
+				}
 				
 				$this->mapProfile($userinfo, 'name', 'info.name');
 				$this->mapProfile($userinfo, 'email', 'info.email');


### PR DESCRIPTION
If your application needs an offline access then after authorization Google will include "refresh_token" parameter in response.

This fix just adds this "refresh_token" to credentials array so you can access it and store after opauth callback.
