### PR TITLE
Add state verification on callback

### DIFF
--- a/GoogleStrategy.php
+++ b/GoogleStrategy.php
@@ -61,6 +61,21 @@ class GoogleStrategy extends OpauthStrategy{
 	 * Internal callback, after OAuth
 	 */
 	public function oauth2callback(){
+		if (isset($this->strategy['state'])){
+                        if (!isset($_GET['state']) || $this->strategy['state'] != $_GET['state']){
+                                $error = array(
+                                        'code' => 'state_error',
+                                        'message' => 'State does not match',
+                                        'raw' => array(
+                                                'response' => filter_input(INPUT_GET, 'state'),
+                                                'expected' => $this->strategy['state']
+                                        )
+                                );
+
+                                $this->errorCallback($error);
+                                return;
+                        }
+                }
 		if (array_key_exists('code', $_GET) && !empty($_GET['code'])){
 			$code = $_GET['code'];
 			$url = 'https://accounts.google.com/o/oauth2/token';


### PR DESCRIPTION
The state paramater is currently neither validated nor passed to the application. This parameter is crucial in avoiding [CSRF-attacks](http://tools.ietf.org/html/rfc6749#section-10.12).

This commit should compare the state parameter from the strategy configuration with the received state parameter from the Google endpoint.