### PR TITLE
Added prompt parameter to request URL in GoogleStrategy.php

### DIFF
--- a/GoogleStrategy.php
+++ b/GoogleStrategy.php
@@ -27,7 +27,7 @@ class GoogleStrategy extends OpauthStrategy{
 	/**
 	 * Optional config keys, without predefining any default values.
 	 */
-	public $optionals = array('redirect_uri', 'scope', 'state', 'access_type', 'approval_prompt');
+	public $optionals = array('redirect_uri', 'scope', 'state', 'access_type', 'approval_prompt','prompt');
 	
 	/**
 	 * Optional config keys with respective default values, listed as associative arrays


### PR DESCRIPTION
Added optional prompt parameter specified here: https://developers.google.com/accounts/docs/OAuth2Login#prompt

Allows applications to force the account chooser or consent screen to show on all logins.
